### PR TITLE
Fixes a 'redefining attribute' js error

### DIFF
--- a/dist/simplr.js
+++ b/dist/simplr.js
@@ -575,19 +575,6 @@
 	            errorCodes : ["eMissingValidator"]
 	        };
 	    },
-	    // not empty
-	    notempty : function(value) {
-	    	var results = {
-	    		valid : true,
-	    		successCodes : [],
-	    		errorCodes : []
-	    	};
-	        if(value.trim() == "") {
-	    		results.valid = false;
-	    		results.errorCodes.push("eEmpty");
-	    	}
-	    	return results;
-	    },
 	    // alphnumeric
 		alphanumeric : function(value) {
 			var results = {


### PR DESCRIPTION
This error occurs in simplr.js, which is js from AMBR. This error
appears to be a redefinition of the 'notempty' validation method. The
definition of 'notempty' that was chosen is the more full-featured of
the two and catches 'empty' cases that the removed definition does not.

This error only arises in browsers whose javascript engines implement
'use strict' correctly; A non-exhaustive list of tested browsers and
whether or not they throw these errors follows.

.-----------------------------------------.
| Browser/JS Engine | Throws these errors |
|-----------------------------------------|
|        webkit     |         YES         |
|        chrome     |          NO         |
|      GNU IceCat   |         YES         |
'-----------------------------------------'

The (speculated) reason that Google Chrome doen't throw errors from this
code is that in javascript land, all runtime behavior is up to
implementation. So, every js engine is free to handle things however
they want.

Yay javascript!

Signed-off-by: zachwick zach@zachwick.com
